### PR TITLE
Don't cut longer playernames off

### DIFF
--- a/rusts.py
+++ b/rusts.py
@@ -48,13 +48,16 @@ def player_list(server):
     print(line_sep)
     print("Rust Version {} ({}ms)".format(version, ping))
     print(line_sep)
-    longestplayername = len(max(players["players"], key=lambda player: len(player["name"])))    
-    for player in sorted(players["players"], key=lambda player: player["name"]):
-        player_name = player["name"]
-        player_minutes = int(player["duration"]) / 60
-        player_hours, player_minutes = divmod(player_minutes, 60)
-        printstr = " " * (longestplayername-len(player_name)) + player_name + ":\t"+"%d hr %02d min" % (player_hours, player_minutes)
-        print (printstr)
+    if len(players["players"]) > 0:
+        longestplayername = len(max(players["players"], key=lambda player: len(player["name"])))    
+        for player in sorted(players["players"], key=lambda player: player["name"]):
+            player_name = player["name"]
+            player_minutes = int(player["duration"]) / 60
+            player_hours, player_minutes = divmod(player_minutes, 60)
+            printstr = " " * (longestplayername-len(player_name)) + player_name + ":\t"+"%d hr %02d min" % (player_hours, player_minutes)
+            print (printstr)
+    else:
+        print ("Nobody Rusting away here :(")
 
     print(line_sep)
     print("%d players / %d max" % (num_players, max_players))

--- a/rusts.py
+++ b/rusts.py
@@ -48,12 +48,13 @@ def player_list(server):
     print(line_sep)
     print("Rust Version {} ({}ms)".format(version, ping))
     print(line_sep)
-
+    longestplayername = len(max(players["players"], key=lambda player: len(player["name"])))    
     for player in sorted(players["players"], key=lambda player: player["name"]):
         player_name = player["name"]
         player_minutes = int(player["duration"]) / 60
         player_hours, player_minutes = divmod(player_minutes, 60)
-        print("%12s:\t %d hr %02d min" % (player_name[:12], player_hours, player_minutes))
+        printstr = " " * (longestplayername-len(player_name)) + player_name + ":\t"+"%d hr %02d min" % (player_hours, player_minutes)
+        print (printstr)
 
     print(line_sep)
     print("%d players / %d max" % (num_players, max_players))


### PR DESCRIPTION
_Prefix: I have limited experience with Python so this does probably look very...'hacky' or even bad._

Previously names that had more than 12 characters would be cut off. With this change, that does not happen anymore. Also the playernames are still aligned to the right. TODO: Find a proper upper limit for the length of a playername and cut playernames that are longer than that to that length.