### PR TITLE
Specify field to get the correct length

### DIFF
--- a/rusts.py
+++ b/rusts.py
@@ -49,7 +49,7 @@ def player_list(server):
     print("Rust Version {} ({}ms)".format(version, ping))
     print(line_sep)
     if len(players["players"]) > 0:
-        longestplayername = len(max(players["players"], key=lambda player: len(player["name"])))    
+        longestplayername = len(max(players["players"], key=lambda player: len(player["name"]))["name"])
         for player in sorted(players["players"], key=lambda player: player["name"]):
             player_name = player["name"]
             player_minutes = int(player["duration"]) / 60


### PR DESCRIPTION
'len' has to check the string inside the 'name' property. Previously the length of the string representation of the Player object was measured - which of course was the same for everyone.